### PR TITLE
Add VT Code to Developer Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ Aside from those listed here, many other apps and libraries can be easily be fou
 - [tracexec](https://github.com/kxxt/tracexec) - Tracer for execve{,at} and pre-exec behavior, launcher for debuggers.
 - [Yozefu](https://github.com/MAIF/yozefu/) - A TUI for exploring data of a Kafka cluster.
 - [Yazi](https://github.com/sxyazi/yazi) - Blazing fast terminal file manager written in Rust, based on async I/O.
+- [VT Code](https://github.com/vinhnx/vtcode) -  VT Code - Semantic Coding Agent.
 
 ### 🕹️ Games and Entertainment
 


### PR DESCRIPTION
Removed VT Code entry from the list of tools.

<!-- Thanks for making Ratatui awesome! 🐭 -->

* Link to your project (GitHub/crates.io): 

1. GitHub: https://github.com/vinhnx/vtcode
2. Crates.io: https://crates.io/crates/vtcode
3. Docs.rs: https://docs.rs/vtcode/latest/vtcode/

* Description (optional): VT Code is a Rust-based terminal coding agent with semantic code understanding and an enhanced TUI experience, powered by Ratatui.

* Screenshot or gif (strongly recommended): 

1. Screenshot: 
<img width="641" height="500" alt="Screenshot 2025-09-24 at 09 25 56" src="https://github.com/user-attachments/assets/3c083c1d-50ba-4830-99dd-7b7d42066c6f" />

2. Gif:

  <img src="https://vhs.charm.sh/vhs-6TOGgem88KCCjE2daGabBV.gif" alt="Made with VHS">
  <a href="https://vhs.charm.sh">
    <img src="https://stuff.charm.sh/vhs/badge.svg">
  </a>
                

Thank you! 🦀 

